### PR TITLE
Introduce project classification 

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,6 +83,8 @@ export {
     StackSupport,
 } from "./lib/analysis/ProjectAnalyzer";
 export {
+    FastProject,
+    ScannerAction,
     TechnologyScanner,
 } from "./lib/analysis/TechnologyScanner";
 export {

--- a/lib/analysis/Interpretation.ts
+++ b/lib/analysis/Interpretation.ts
@@ -202,8 +202,8 @@ export function buildGoals(interpretation: Interpretation, analyzer: ProjectAnal
 /**
  * Messaging goals. Only set if there are messages in this interpretation.
  */
-export function messagingGoals(interpretation: Interpretation, analyzer: ProjectAnalyzer): Goals {
-    if (interpretation.messages.length > 0) {
+export function messagingGoals(hasMessages: HasMessages, analyzer: ProjectAnalyzer): Goals {
+    if (hasMessages.messages.length > 0) {
         return goals("messages").plan(analyzer.messageGoal);
     }
     return undefined;

--- a/lib/analysis/Interpretation.ts
+++ b/lib/analysis/Interpretation.ts
@@ -31,14 +31,14 @@ import { DeliveryPhases } from "./phases";
 import { ProjectAnalysis } from "./ProjectAnalysis";
 import { ProjectAnalyzer } from "./ProjectAnalyzer";
 import { Scores } from "./Score";
-import { PushMessage } from "./support/messageGoal";
+import { HasMessages } from "./support/messageGoal";
 
 /**
  * Consolidated interpretation. Unlike a ProjectAnalysis, an interpretation is not
  * intended to be persisted, but is only held in memory.
  * Interpreters add to an Interpretation's goals, considering what goals may already have been set.
  */
-export interface Interpretation extends DeliveryPhases {
+export interface Interpretation extends DeliveryPhases, HasMessages {
 
     /**
      * The data on which we arrived at this interpretation
@@ -79,12 +79,6 @@ export interface Interpretation extends DeliveryPhases {
     readonly codeInspectionGoal: AutoCodeInspection;
 
     readonly scores: Scores;
-
-    /**
-     * Any messages regarding this project or push that should be displayed
-     * to users when handling the project.
-     */
-    readonly messages: PushMessage[];
 
 }
 

--- a/lib/analysis/ProjectAnalysis.ts
+++ b/lib/analysis/ProjectAnalysis.ts
@@ -98,11 +98,7 @@ export interface ProjectAnalysis {
 
 }
 
-/**
- * Instance of a known element type, such as NodeTechnologyElement,
- * in a specific project.
- */
-export interface TechnologyElement {
+export interface Classified {
 
     /**
      * Name of the element, such as "node".
@@ -114,6 +110,13 @@ export interface TechnologyElement {
      * Tags associated with this element's use.
      */
     readonly tags: string[];
+}
+
+/**
+ * Instance of a known element type, such as NodeTechnologyElement,
+ * in a specific project.
+ */
+export interface TechnologyElement extends Classified {
 
     /**
      * Names of environment variables referenced by this stack.

--- a/lib/analysis/ProjectAnalyzer.ts
+++ b/lib/analysis/ProjectAnalyzer.ts
@@ -28,6 +28,7 @@ import {
     Interpreter,
 } from "./Interpretation";
 import {
+    Classified,
     ProjectAnalysis,
     ProjectAnalysisOptions,
     TechnologyElement,
@@ -35,7 +36,6 @@ import {
 import { Score } from "./Score";
 import {
     FastProject,
-    RelevanceTest,
     ScannerAction,
     TechnologyScanner,
 } from "./TechnologyScanner";
@@ -76,6 +76,14 @@ export function isConditionalRegistration(a: any): a is ConditionalRegistration<
 export type Scorer = (i: Interpretation, ctx: SdmContext) => Promise<Score>;
 
 /**
+ * Project pre-check
+ */
+export interface Classification {
+
+    elements: Record<string, Classified>;
+}
+
+/**
  * Type with ability to analyze individual projects and determine their delivery.
  * We use a fixed set of goals created ahead of time with function implementations
  * that are parameterized based on analyzing and interpreting the project on push.
@@ -83,9 +91,9 @@ export type Scorer = (i: Interpretation, ctx: SdmContext) => Promise<Score>;
 export interface ProjectAnalyzer {
 
     /**
-     * Is this project relevant?
+     * Classify this project
      */
-    isRelevant: RelevanceTest;
+    classify(p: FastProject, sdmContext: SdmContext): Promise<Classification>;
 
     /**
      * Analyze the given project. Analysis will always be in sufficient detail to back delivery.

--- a/lib/analysis/ProjectAnalyzer.ts
+++ b/lib/analysis/ProjectAnalyzer.ts
@@ -33,7 +33,12 @@ import {
     TechnologyElement,
 } from "./ProjectAnalysis";
 import { Score } from "./Score";
-import { FastProject, RelevanceTest, ScannerAction, TechnologyScanner } from "./TechnologyScanner";
+import {
+    FastProject,
+    RelevanceTest,
+    ScannerAction,
+    TechnologyScanner,
+} from "./TechnologyScanner";
 import { TransformRecipeContributionRegistration } from "./TransformRecipeContributor";
 
 /**

--- a/lib/analysis/ProjectAnalyzer.ts
+++ b/lib/analysis/ProjectAnalyzer.ts
@@ -33,7 +33,7 @@ import {
     TechnologyElement,
 } from "./ProjectAnalysis";
 import { Score } from "./Score";
-import { TechnologyScanner } from "./TechnologyScanner";
+import { FastProject, RelevanceTest, ScannerAction, TechnologyScanner } from "./TechnologyScanner";
 import { TransformRecipeContributionRegistration } from "./TransformRecipeContributor";
 
 /**
@@ -78,6 +78,11 @@ export type Scorer = (i: Interpretation, ctx: SdmContext) => Promise<Score>;
 export interface ProjectAnalyzer {
 
     /**
+     * Is this project relevant?
+     */
+    isRelevant: RelevanceTest;
+
+    /**
      * Analyze the given project. Analysis will always be in sufficient detail to back delivery.
      * If options are provided and specify a full analysis, go deeper.
      */
@@ -90,7 +95,7 @@ export interface ProjectAnalyzer {
 
     readonly interpreters: Array<ConditionalRegistration<Interpreter>>;
 
-    readonly scanners: Array<ConditionalRegistration<TechnologyScanner<any>>>;
+    readonly scanners: Array<ConditionalRegistration<ScannerAction<any>>>;
 
     readonly scorers: Array<ConditionalRegistration<Scorer>>;
 
@@ -144,7 +149,7 @@ export interface ProjectAnalyzerBuilder {
      * of previous analyzers. This ensure that expensive parsing
      * can be done only once.
      */
-    withScanner<T extends TechnologyElement>(scanner: TechnologyScanner<T> | ConditionalRegistration<TechnologyScanner<T>>): ProjectAnalyzerBuilder;
+    withScanner<T extends TechnologyElement>(scanner: ScannerAction<T> | ConditionalRegistration<ScannerAction<T>>): ProjectAnalyzerBuilder;
 
     /**
      * Add an interpreter that can interpret the analysis.

--- a/lib/analysis/ProjectAnalyzer.ts
+++ b/lib/analysis/ProjectAnalyzer.ts
@@ -76,7 +76,7 @@ export function isConditionalRegistration(a: any): a is ConditionalRegistration<
 export type Scorer = (i: Interpretation, ctx: SdmContext) => Promise<Score>;
 
 /**
- * Project pre-check
+ * Result of classifying the project quickly to determine its nature.
  */
 export interface Classification {
 
@@ -91,7 +91,8 @@ export interface Classification {
 export interface ProjectAnalyzer {
 
     /**
-     * Classify this project
+     * Classify this project. The implementations should be faster than delivery steps of interpretation and analysis.
+     * Allows a project to be classified quickly to determine the relevance of this SDM to handling it.
      */
     classify(p: FastProject, sdmContext: SdmContext): Promise<Classification>;
 

--- a/lib/analysis/ProjectAnalyzer.ts
+++ b/lib/analysis/ProjectAnalyzer.ts
@@ -28,7 +28,6 @@ import {
     Interpreter,
 } from "./Interpretation";
 import {
-    Classified,
     ProjectAnalysis,
     ProjectAnalysisOptions,
     TechnologyElement,
@@ -36,7 +35,7 @@ import {
 import { Score } from "./Score";
 import {
     FastProject,
-    ScannerAction,
+    ScannerAction, TechnologyClassification,
     TechnologyScanner,
 } from "./TechnologyScanner";
 import { TransformRecipeContributionRegistration } from "./TransformRecipeContributor";
@@ -80,7 +79,7 @@ export type Scorer = (i: Interpretation, ctx: SdmContext) => Promise<Score>;
  */
 export interface Classification {
 
-    elements: Record<string, Classified>;
+    elements: Record<string, TechnologyClassification>;
 }
 
 /**

--- a/lib/analysis/ProjectAnalyzer.ts
+++ b/lib/analysis/ProjectAnalyzer.ts
@@ -35,7 +35,8 @@ import {
 import { Score } from "./Score";
 import {
     FastProject,
-    ScannerAction, TechnologyClassification,
+    ScannerAction,
+    TechnologyClassification,
     TechnologyScanner,
 } from "./TechnologyScanner";
 import { TransformRecipeContributionRegistration } from "./TransformRecipeContributor";

--- a/lib/analysis/TechnologyScanner.ts
+++ b/lib/analysis/TechnologyScanner.ts
@@ -41,6 +41,9 @@ export type FastProject = Pick<Project, "id" | "findFile" | "hasFile" | "getFile
 export type TechnologyScanner<T extends TechnologyElement> =
     (p: Project, ctx: SdmContext, analysisSoFar: ProjectAnalysis, options: ProjectAnalysisOptions) => Promise<T | undefined>;
 
+/**
+ * Result of quickly classifying a project.
+ */
 export type TechnologyClassification = Classified & HasMessages;
 
 /**
@@ -49,17 +52,17 @@ export type TechnologyClassification = Classified & HasMessages;
 export interface PhasedTechnologyScanner<T extends TechnologyElement> {
 
     /**
-     * Quck classification of this project. Should be efficient.
+     * Quick classification of this project. Should be efficient.
      */
     classify: (p: FastProject, ctx: SdmContext) => Promise<TechnologyClassification | undefined>;
 
     /**
-     * Perform a scan
+     * Perform a scan of the project.
      */
     scan: TechnologyScanner<T>;
 }
 
-export function isPhasedScanner(a: any): a is PhasedTechnologyScanner<any> {
+export function isPhasedTechnologyScanner(a: any): a is PhasedTechnologyScanner<any> {
     const maybe = a as PhasedTechnologyScanner<any>;
     return !!maybe.scan;
 }

--- a/lib/analysis/TechnologyScanner.ts
+++ b/lib/analysis/TechnologyScanner.ts
@@ -17,10 +17,12 @@
 import { Project } from "@atomist/automation-client";
 import { SdmContext } from "@atomist/sdm";
 import {
+    Classified,
     ProjectAnalysis,
     ProjectAnalysisOptions,
     TechnologyElement,
 } from "./ProjectAnalysis";
+import { HasMessages } from "./support/messageGoal";
 
 /**
  * Subset of Project that is efficient and can be used during a precheck
@@ -39,12 +41,7 @@ export type FastProject = Pick<Project, "id" | "findFile" | "hasFile" | "getFile
 export type TechnologyScanner<T extends TechnologyElement> =
     (p: Project, ctx: SdmContext, analysisSoFar: ProjectAnalysis, options: ProjectAnalysisOptions) => Promise<T | undefined>;
 
-/**
- * Test as to whether a Project is relevant. Such tests should run fast
- * as they cannot scan the entire project and thus the infrastructure
- * can avoid cloning.
- */
-export type RelevanceTest = (p: FastProject, ctx: SdmContext) => Promise<boolean>;
+export type TechnologyClassification = Classified & HasMessages;
 
 /**
  * More elaborate scanner that can work in phases
@@ -52,9 +49,9 @@ export type RelevanceTest = (p: FastProject, ctx: SdmContext) => Promise<boolean
 export interface PhasedTechnologyScanner<T extends TechnologyElement> {
 
     /**
-     * Check whether this project might be relevant. Should be efficient.
+     * Quck classification of this project. Should be efficient.
      */
-    isRelevant: RelevanceTest;
+    classify: (p: FastProject, ctx: SdmContext) => Promise<TechnologyClassification | undefined>;
 
     /**
      * Perform a scan

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -60,7 +60,12 @@ import {
     Scorer,
     StackSupport,
 } from "../ProjectAnalyzer";
-import { FastProject, isPhasedScanner, PhasedTechnologyScanner, ScannerAction } from "../TechnologyScanner";
+import {
+    FastProject,
+    isPhasedScanner,
+    PhasedTechnologyScanner,
+    ScannerAction,
+} from "../TechnologyScanner";
 import { TransformRecipeContributionRegistration } from "../TransformRecipeContributor";
 import {
     registerAutofixes,

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -64,7 +64,7 @@ import {
 } from "../ProjectAnalyzer";
 import {
     FastProject,
-    isPhasedScanner,
+    isPhasedTechnologyScanner,
     PhasedTechnologyScanner,
     ScannerAction,
 } from "../TechnologyScanner";
@@ -351,7 +351,7 @@ function runOnCondition<W>(action: W, runWhen: RunCondition = () => true): Condi
 }
 
 function toPhasedTechnologyScanner<T extends TechnologyElement>(sa: ScannerAction<T>): PhasedTechnologyScanner<T> {
-    return isPhasedScanner(sa) ?
+    return isPhasedTechnologyScanner(sa) ?
         sa :
         {
             // If it wants to be classified, it has to do work

--- a/lib/analysis/support/messageGoal.ts
+++ b/lib/analysis/support/messageGoal.ts
@@ -49,6 +49,18 @@ export interface PushMessage {
 }
 
 /**
+ * Extended by any type that can have messages associated with it.
+ */
+export interface HasMessages {
+
+    /**
+     * Any messages regarding this project or push that should be displayed
+     * to users when handling the project.
+     */
+    readonly messages: PushMessage[];
+}
+
+/**
  * Factory that is able to produce PushMessages
  */
 export type PushMessageFactory = (gi: GoalInvocation) => Promise<PushMessage[]>;

--- a/lib/analysis/support/projectAnalysisUtils.ts
+++ b/lib/analysis/support/projectAnalysisUtils.ts
@@ -20,10 +20,23 @@ import {
 } from "../ProjectAnalysis";
 
 import * as _ from "lodash";
+import { Classification } from "../ProjectAnalyzer";
+import { PushMessage } from "./messageGoal";
+import { TechnologyClassification } from "../TechnologyScanner";
 
 export function allTechnologyElements(projectAnalysis: ProjectAnalysis): TechnologyElement[] {
     return Object.getOwnPropertyNames(projectAnalysis.elements)
         .map(name => projectAnalysis.elements[name]);
+}
+
+export function allTechnologyClassifications(classification: Classification): TechnologyClassification[] {
+    return Object.getOwnPropertyNames(classification.elements)
+        .map(name => classification.elements[name]);
+}
+
+export function allMessages(classification: Classification): PushMessage[] {
+    return _.flatten(allTechnologyClassifications(classification)
+        .map(cl => cl.messages));
 }
 
 /**

--- a/lib/analysis/support/projectAnalysisUtils.ts
+++ b/lib/analysis/support/projectAnalysisUtils.ts
@@ -21,8 +21,8 @@ import {
 
 import * as _ from "lodash";
 import { Classification } from "../ProjectAnalyzer";
-import { PushMessage } from "./messageGoal";
 import { TechnologyClassification } from "../TechnologyScanner";
+import { PushMessage } from "./messageGoal";
 
 export function allTechnologyElements(projectAnalysis: ProjectAnalysis): TechnologyElement[] {
     return Object.getOwnPropertyNames(projectAnalysis.elements)

--- a/test/analysis/projectAnalyzer.test.ts
+++ b/test/analysis/projectAnalyzer.test.ts
@@ -35,46 +35,50 @@ describe("projectAnalyzer", () => {
 
     describe("relevance", () => {
 
-        it("should not be relevant by default", async () => {
+        it("should not be classified by default", async () => {
             const p = InMemoryProject.of();
-            const relevant = await analyzerBuilder({} as any).withScanner(toyScanner).build()
-                .isRelevant(p, undefined);
-            assert(!relevant);
+            const classification = await analyzerBuilder({} as any).withScanner(toyScanner).build()
+                .classify(p, undefined);
+            assert(!!classification);
+            assert.deepStrictEqual(classification, { elements: {}});
         });
 
-        it("should be relevant with true precheck", async () => {
+        it("should be classified with classification", async () => {
             const p = InMemoryProject.of();
-            const relevant = await analyzerBuilder({} as any).withScanner({
-                isRelevant: async () => true,
+            const classification = await analyzerBuilder({} as any).withScanner({
+                classify: async () => ({name: "foo", tags: [], messages: []}),
                 scan: toyScanner,
             }).build()
-                .isRelevant(p, undefined);
-            assert(relevant);
+                .classify(p, undefined);
+            assert(!!classification);
+            assert(!!classification.elements.foo);
         });
 
-        it("should not be relevant with false precheck", async () => {
+        it("should not be classified with no classification", async () => {
             const p = InMemoryProject.of();
-            const relevant = await analyzerBuilder({} as any).withScanner({
-                isRelevant: async () => false,
+            const classification = await analyzerBuilder({} as any).withScanner({
+                classify: async () => undefined,
                 scan: toyScanner,
             }).build()
-                .isRelevant(p, undefined);
-            assert(!relevant);
+                .classify(p, undefined);
+            assert(!!classification);
+            assert.deepStrictEqual(classification, { elements: {}});
         });
 
-        it("should be relevant with one true and one false precheck", async () => {
+        it("should be classified with one true and one false classification", async () => {
             const p = InMemoryProject.of();
-            const relevant = await analyzerBuilder({} as any)
+            const classified = await analyzerBuilder({} as any)
                 .withScanner({
-                    isRelevant: async () => true,
+                    classify: async () => ({ name: "foo", tags: [], messages: []}),
                     scan: toyScanner,
                 })
                 .withScanner({
-                    isRelevant: async () => false,
+                    classify: async () => undefined,
                     scan: toyScanner,
                 }).build()
-                .isRelevant(p, undefined);
-            assert(relevant);
+                .classify(p, undefined);
+            assert(!!classified);
+            assert(!!classified.elements.foo);
         });
 
     });

--- a/test/analysis/projectAnalyzer.test.ts
+++ b/test/analysis/projectAnalyzer.test.ts
@@ -136,7 +136,7 @@ describe("projectAnalyzer", () => {
                 .withTransformRecipeContributor({
                     originator: "snip",
                     optional: true,
-                    contributor: new SnipTransformRecipeContributor()
+                    contributor: new SnipTransformRecipeContributor(),
                 })
                 .withTransformRecipeContributor(AlwaysTRC).build()
                 .analyze(p, pli, { full: true });

--- a/test/analysis/projectAnalyzer.test.ts
+++ b/test/analysis/projectAnalyzer.test.ts
@@ -33,6 +33,52 @@ import { TransformRecipeContributionRegistration } from "../../lib/analysis/Tran
 
 describe("projectAnalyzer", () => {
 
+    describe("relevance", () => {
+
+        it("should not be relevant by default", async () => {
+            const p = InMemoryProject.of();
+            const relevant = await analyzerBuilder({} as any).withScanner(toyScanner).build()
+                .isRelevant(p, undefined);
+            assert(!relevant);
+        });
+
+        it("should be relevant with true precheck", async () => {
+            const p = InMemoryProject.of();
+            const relevant = await analyzerBuilder({} as any).withScanner({
+                isRelevant: async () => true,
+                scan: toyScanner,
+            }).build()
+                .isRelevant(p, undefined);
+            assert(relevant);
+        });
+
+        it("should not be relevant with false precheck", async () => {
+            const p = InMemoryProject.of();
+            const relevant = await analyzerBuilder({} as any).withScanner({
+                isRelevant: async () => false,
+                scan: toyScanner,
+            }).build()
+                .isRelevant(p, undefined);
+            assert(!relevant);
+        });
+
+        it("should be relevant with one true and one false precheck", async () => {
+            const p = InMemoryProject.of();
+            const relevant = await analyzerBuilder({} as any)
+                .withScanner({
+                    isRelevant: async () => true,
+                    scan: toyScanner,
+                })
+                .withScanner({
+                    isRelevant: async () => false,
+                    scan: toyScanner,
+                }).build()
+                .isRelevant(p, undefined);
+            assert(relevant);
+        });
+
+    });
+
     describe("analysis", () => {
 
         it("should pull up services", async () => {
@@ -90,7 +136,8 @@ describe("projectAnalyzer", () => {
                 .withTransformRecipeContributor({
                     originator: "snip",
                     optional: true,
-                    contributor: new SnipTransformRecipeContributor()})
+                    contributor: new SnipTransformRecipeContributor()
+                })
                 .withTransformRecipeContributor(AlwaysTRC).build()
                 .analyze(p, pli, { full: true });
             assert.strictEqual(analyzer.seedAnalysis.transformRecipes.length, 2);


### PR DESCRIPTION
Introduces a new phase of analysis to classify a project to see whether we're likely to be able to help with further goals. Ensures that the implementations of classifiers are fast as they don't have access to the full `Project` API but only the more efficient methods of `Project`.