### PR TITLE
Expose more data on ProjectAnalysis

### DIFF
--- a/lib/analysis/Interpretation.ts
+++ b/lib/analysis/Interpretation.ts
@@ -73,6 +73,10 @@ export interface Interpretation extends DeliveryPhases, HasMessages {
     readonly materialChangePushTests: PushTest[];
 
     readonly autofixes: AutofixRegistration[];
+
+    /**
+     * Inspections relevant to this Interpretation.
+     */
     readonly inspections: Array<AutoInspectRegistration<any, any>>;
 
     readonly autofixGoal: Autofix;

--- a/lib/analysis/ProjectAnalysis.ts
+++ b/lib/analysis/ProjectAnalysis.ts
@@ -23,6 +23,7 @@ import {
     HasDefaultValue,
     MappedParameterOrSecretDeclaration,
 } from "@atomist/sdm";
+import { Scores } from "./Score";
 
 /**
  * Definition of a service such as riak or mongodb
@@ -36,6 +37,11 @@ export interface Service {
 export type Services = Record<string, Service>;
 
 export type Elements = Record<string, TechnologyElement>;
+
+/**
+ * Results of running code inspections on the current project
+ */
+export type InspectionResults = Record<string, object>;
 
 /**
  * Cross-platform representation of a dependency
@@ -95,6 +101,16 @@ export interface ProjectAnalysis {
      * Only available on a full analysis
      */
     seedAnalysis?: SeedAnalysis;
+
+    /**
+     * Inspections. Only performed on a full analysis
+     */
+    inspections?: InspectionResults;
+
+    /**
+     * Scores. Only performed on a full analysis
+     */
+    scores?: Scores;
 
 }
 

--- a/lib/analysis/ProjectAnalysis.ts
+++ b/lib/analysis/ProjectAnalysis.ts
@@ -24,6 +24,7 @@ import {
     MappedParameterOrSecretDeclaration,
 } from "@atomist/sdm";
 import { Scores } from "./Score";
+import { HasMessages } from "./support/messageGoal";
 
 /**
  * Definition of a service such as riak or mongodb
@@ -66,7 +67,7 @@ export interface ProjectAnalysisOptions {
  * so that Interpreters don't need to refer to the project.
  * Analyses can be persisted.
  */
-export interface ProjectAnalysis {
+export interface ProjectAnalysis extends HasMessages {
 
     /**
      * Options used to perform this analysis.

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -42,8 +42,8 @@ import {
 import {
     Dependency,
     Elements,
-    InspectionResults,
     HasAnalysis,
+    InspectionResults,
     ProjectAnalysis,
     ProjectAnalysisOptions,
     SeedAnalysis,

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -236,6 +236,7 @@ export class DefaultProjectAnalyzerBuilder implements ProjectAnalyzer, ProjectAn
             services,
             dependencies,
             referencedEnvironmentVariables,
+            messages: [],
         };
 
         const scanned = (await Promise.all(this.scanners
@@ -262,6 +263,7 @@ export class DefaultProjectAnalyzerBuilder implements ProjectAnalyzer, ProjectAn
             // We'll need to get more from the interpretation
             const interpretation = await this.runInterpretation(analysis, sdmContext, options);
             analysis.scores = interpretation.scores;
+            analysis.messages.push(...interpretation.messages);
             analysis.inspections = await runInspections(p, interpretation.inspections);
         }
         return analysis;

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -41,7 +41,8 @@ import {
 } from "../Interpretation";
 import {
     Dependency,
-    Elements, InspectionResults,
+    Elements,
+    InspectionResults,
     ProjectAnalysis,
     ProjectAnalysisOptions,
     SeedAnalysis,

--- a/test/analysis/projectAnalyzer.test.ts
+++ b/test/analysis/projectAnalyzer.test.ts
@@ -22,7 +22,10 @@ import {
 } from "@atomist/sdm";
 import * as assert from "assert";
 import { analyzerBuilder } from "../../lib/analysis/analyzerBuilder";
-import { CodeInspectionRegisteringInterpreter, Interpreter } from "../../lib/analysis/Interpretation";
+import {
+    CodeInspectionRegisteringInterpreter,
+    Interpreter,
+} from "../../lib/analysis/Interpretation";
 import {
     Scorer,
     StackSupport,

--- a/test/analysis/projectAnalyzer.test.ts
+++ b/test/analysis/projectAnalyzer.test.ts
@@ -205,6 +205,31 @@ describe("projectAnalyzer", () => {
             assert.deepStrictEqual(analysis.inspections, { foo: { bar: true } });
         });
 
+        it("should not return messages unless asked", async () => {
+            const pli: PushListenerInvocation = { push: {} } as any;
+            const p = InMemoryProject.of();
+            const analysis = await analyzerBuilder({} as any).withScanner(toyScanner).build()
+                .analyze(p, pli, { full: false });
+            assert.strictEqual(analysis.messages.length, 0);
+        });
+
+        it("should find concrete message when asked", async () => {
+            const pli: PushListenerInvocation = { push: {} } as any;
+            const p = InMemoryProject.of();
+            const i: Interpreter = {
+                enrich: async interpretation => {
+                    interpretation.messages.push({ message: "foobar" });
+                    return true;
+                },
+            };
+            const analysis = await analyzerBuilder({} as any)
+                .withScanner(toyScanner)
+                .withInterpreter(i)
+                .build()
+                .analyze(p, pli, { full: true });
+            assert.deepStrictEqual(analysis.messages, [{ message: "foobar" }]);
+        });
+
     });
 
     describe("interpretation", () => {

--- a/test/analysis/support/projectAnalysisUtils.test.ts
+++ b/test/analysis/support/projectAnalysisUtils.test.ts
@@ -54,7 +54,7 @@ describe("projectAnalysisUtils", () => {
                         originator: "foo",
                         description: "foo",
                         recipe: {
-                            parameters: [ {
+                            parameters: [{
                                 name: "thing",
                             }],
                             transforms: [],
@@ -77,5 +77,6 @@ function newAnalysis(): ProjectAnalysis {
         dependencies: [],
         referencedEnvironmentVariables: [],
         services: {},
+        messages: [],
     };
 }


### PR DESCRIPTION
When a `ProjectAnalyzer` performs a full analysis, run interpretation to add more data, which may be persisted. The data added is:

- messages
- scores
- inspection results. From the `Interpretation` we can find the relevant code inspections and run them

Also allow messages to be added to `ProjectAnalysis`.

Does not change delivery behavior, which does not perform a "full" analysis