### PR TITLE
Expose Uhura goal status on full analysis

### DIFF
--- a/lib/analysis/ProjectAnalysis.ts
+++ b/lib/analysis/ProjectAnalysis.ts
@@ -23,6 +23,7 @@ import {
     HasDefaultValue,
     MappedParameterOrSecretDeclaration,
 } from "@atomist/sdm";
+import { DeliveryPhases } from "./phases";
 import { Scores } from "./Score";
 import { HasMessages } from "./support/messageGoal";
 
@@ -108,7 +109,7 @@ export interface ProjectAnalysis extends HasMessages {
     seedAnalysis?: SeedAnalysis;
 
     /**
-     * Inspections. Only performed on a full analysis
+     * Results of code inspections. Only performed on a full analysis.
      */
     inspections?: InspectionResults;
 
@@ -116,6 +117,13 @@ export interface ProjectAnalysis extends HasMessages {
      * Scores. Only performed on a full analysis
      */
     scores?: Scores;
+
+    /**
+     * Lets us know whether the current Uhura SDM (if we are in one) could deliver this project,
+     * allowing querying and assessment of how far the organization is from Uhura-ready.
+     * Only performed on a full analysis, because it requires running an interpretation.
+     */
+    phaseStatus?: Record<keyof DeliveryPhases, boolean>;
 
 }
 

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -267,6 +267,19 @@ export class DefaultProjectAnalyzerBuilder implements ProjectAnalyzer, ProjectAn
             analysis.scores = interpretation.scores;
             analysis.messages.push(...interpretation.messages);
             analysis.inspections = await runInspections(p, interpretation.inspections);
+            // Unfortunately there's no way to see this at runtime, so we need to hardcode.
+            // At least it's checked by the compiler, so will stay in sync
+            analysis.phaseStatus = {
+                containerBuildGoals: !!interpretation.containerBuildGoals,
+                checkGoals: !!interpretation.checkGoals,
+                deployGoals: !!interpretation.deployGoals,
+                releaseGoals: !!interpretation.releaseGoals,
+                cancelGoal: !!interpretation.cancelGoal,
+                deliveryStartedGoals: !!interpretation.deliveryStartedGoals,
+                queueGoal: !!interpretation.queueGoal,
+                buildGoals: !!interpretation.buildGoals,
+                testGoals: !!interpretation.testGoals,
+            };
         }
         return analysis;
     }

--- a/lib/analysis/support/messageGoal.ts
+++ b/lib/analysis/support/messageGoal.ts
@@ -27,7 +27,6 @@ import {
     Goal,
     GoalInvocation,
     SdmContext,
-    SdmGoalEvent,
     slackFooter,
     slackInfoMessage,
     slackSuccessMessage,
@@ -146,8 +145,10 @@ export function messageGoal(messageFactory: PushMessageFactory): Goal {
                 const lastAttachment = attachments.slice(-1)[0];
                 lastAttachment.footer = slackFooter();
                 lastAttachment.ts = slackTs();
-                lastAttachment.actions =
-                    [...(lastAttachment.actions || []), ...(pushMessages.length > 1 ? [createDismissAllAction(pushMessages, goalEvent.repo, options.id)] : [])];
+                lastAttachment.actions = [
+                    ...(lastAttachment.actions || []),
+                    ...(pushMessages.length > 1 ? [createDismissAllAction(pushMessages, goalEvent.repo, options.id)] : []),
+                ];
 
                 await addressMessage(msg, gi, {});
             }

--- a/test/analysis/projectAnalyzer.test.ts
+++ b/test/analysis/projectAnalyzer.test.ts
@@ -233,6 +233,44 @@ describe("projectAnalyzer", () => {
             assert.deepStrictEqual(analysis.messages, [{ message: "foobar" }]);
         });
 
+        it("should not find phases status when not asked", async () => {
+            const pli: PushListenerInvocation = { push: {} } as any;
+            const p = InMemoryProject.of();
+            const buildGoals = goals("thing");
+            const i: Interpreter = {
+                enrich: async interpretation => {
+                    interpretation.buildGoals = buildGoals;
+                    return true;
+                },
+            };
+            const analysis = await analyzerBuilder({} as any)
+                .withScanner(toyScanner)
+                .withInterpreter(i)
+                .build()
+                .analyze(p, pli, { full: false });
+            assert(!analysis.phaseStatus);
+        });
+
+        it("should find phases status when asked", async () => {
+            const pli: PushListenerInvocation = { push: {} } as any;
+            const p = InMemoryProject.of();
+            const buildGoals = goals("thing");
+            const i: Interpreter = {
+                enrich: async interpretation => {
+                    interpretation.buildGoals = buildGoals;
+                    return true;
+                },
+            };
+            const analysis = await analyzerBuilder({} as any)
+                .withScanner(toyScanner)
+                .withInterpreter(i)
+                .build()
+                .analyze(p, pli, { full: true });
+            assert(!!analysis.phaseStatus);
+            assert.strictEqual(analysis.phaseStatus.buildGoals, true);
+            assert.strictEqual(analysis.phaseStatus.deployGoals, false);
+        });
+
     });
 
     describe("interpretation", () => {


### PR DESCRIPTION
In a full analysis, include goal status for Uhura delivery. This enables querying an organization to see how much Uhura it can benefit from.