### PR TITLE
Add fingerprint support

### DIFF
--- a/lib/analysis/ProjectAnalysis.ts
+++ b/lib/analysis/ProjectAnalysis.ts
@@ -26,6 +26,7 @@ import {
 import { DeliveryPhases } from "./phases";
 import { Scores } from "./Score";
 import { HasMessages } from "./support/messageGoal";
+import { Fingerprint } from "@atomist/automation-client/lib/project/fingerprint/Fingerprint";
 
 /**
  * Definition of a service such as riak or mongodb
@@ -64,6 +65,8 @@ export interface ProjectAnalysisOptions {
 export interface HasAnalysis {
     analysis?: ProjectAnalysis;
 }
+
+export type ConsolidatedFingerprints = Record<string, Fingerprint>;
 
 /**
  * An analysis of the various facets of a project.
@@ -130,6 +133,13 @@ export interface ProjectAnalysis extends HasMessages {
      */
     gitStatus?: { branch: string, sha: string };
 
+    /**
+     * Fingerprints found in this structure. Unpacked from individual scanner contributions.
+     * Empty object if no fingerprints returned by any scanner.
+     * Fingerprinting is performed on all pushes.
+     */
+    readonly fingerprints: ConsolidatedFingerprints;
+
 }
 
 export interface Classified {
@@ -161,6 +171,11 @@ export interface TechnologyElement extends Classified {
      * Any services required by this element
      */
     readonly services?: Services;
+
+    /**
+     * Individual fingerprints if any, within this structure
+     */
+    readonly fingerprints?: Fingerprint[];
 
 }
 

--- a/lib/analysis/ProjectAnalysis.ts
+++ b/lib/analysis/ProjectAnalysis.ts
@@ -66,6 +66,9 @@ export interface HasAnalysis {
     analysis?: ProjectAnalysis;
 }
 
+/**
+ * All fingerprints from individual scanners, in a record type.
+ */
 export type ConsolidatedFingerprints = Record<string, Fingerprint>;
 
 /**
@@ -173,7 +176,8 @@ export interface TechnologyElement extends Classified {
     readonly services?: Services;
 
     /**
-     * Individual fingerprints if any, within this structure
+     * Individual fingerprints if any, within this structure.
+     * The names of fingerprints must be globally unique.
      */
     readonly fingerprints?: Fingerprint[];
 

--- a/lib/analysis/ProjectAnalysis.ts
+++ b/lib/analysis/ProjectAnalysis.ts
@@ -18,6 +18,7 @@ import {
     BaseParameter,
     RemoteRepoRef,
 } from "@atomist/automation-client";
+import { Fingerprint } from "@atomist/automation-client/lib/project/fingerprint/Fingerprint";
 import {
     CodeTransform,
     HasDefaultValue,
@@ -26,7 +27,6 @@ import {
 import { DeliveryPhases } from "./phases";
 import { Scores } from "./Score";
 import { HasMessages } from "./support/messageGoal";
-import { Fingerprint } from "@atomist/automation-client/lib/project/fingerprint/Fingerprint";
 
 /**
  * Definition of a service such as riak or mongodb

--- a/lib/analysis/TechnologyScanner.ts
+++ b/lib/analysis/TechnologyScanner.ts
@@ -67,4 +67,14 @@ export function isPhasedTechnologyScanner(a: any): a is PhasedTechnologyScanner<
     return !!maybe.scan;
 }
 
+export function toPhasedTechnologyScanner<T extends TechnologyElement>(sa: ScannerAction<T>): PhasedTechnologyScanner<T> {
+    return isPhasedTechnologyScanner(sa) ?
+        sa :
+        {
+            // If it wants to be classified, it has to do work
+            classify: async () => undefined,
+            scan: sa,
+        };
+}
+
 export type ScannerAction<T extends TechnologyElement> = TechnologyScanner<T> | PhasedTechnologyScanner<T>;

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -67,7 +67,8 @@ import {
 import {
     FastProject,
     PhasedTechnologyScanner,
-    ScannerAction, toPhasedTechnologyScanner,
+    ScannerAction,
+    toPhasedTechnologyScanner,
 } from "../TechnologyScanner";
 import { TransformRecipeContributionRegistration } from "../TransformRecipeContributor";
 import {

--- a/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
+++ b/lib/analysis/support/DefaultProjectAnalyzerBuilder.ts
@@ -41,6 +41,7 @@ import {
     isCodeInspectionRegisteringInterpreter,
 } from "../Interpretation";
 import {
+    ConsolidatedFingerprints,
     Dependency,
     Elements,
     HasAnalysis,
@@ -232,6 +233,7 @@ export class DefaultProjectAnalyzerBuilder implements ProjectAnalyzer, ProjectAn
         const services: Services = {};
         const dependencies: Dependency[] = [];
         const referencedEnvironmentVariables: string[] = [];
+        const fingerprints: ConsolidatedFingerprints = {};
         const analysis: ProjectAnalysis = {
             id: p.id as RemoteRepoRef,
             options,
@@ -240,6 +242,7 @@ export class DefaultProjectAnalyzerBuilder implements ProjectAnalyzer, ProjectAn
             dependencies,
             referencedEnvironmentVariables,
             messages: [],
+            fingerprints,
         };
 
         const scanned = (await Promise.all(this.scanners
@@ -258,6 +261,9 @@ export class DefaultProjectAnalyzerBuilder implements ProjectAnalyzer, ProjectAn
             if (!!s.referencedEnvironmentVariables) {
                 referencedEnvironmentVariables.push(
                     ...s.referencedEnvironmentVariables.filter((e: string) => !referencedEnvironmentVariables.includes(e)));
+            }
+            if (!!s.fingerprints) {
+                s.fingerprints.forEach((fp: any) => fingerprints[fp.name] = fp);
             }
         }
 

--- a/test/analysis/projectAnalyzer.test.ts
+++ b/test/analysis/projectAnalyzer.test.ts
@@ -271,6 +271,37 @@ describe("projectAnalyzer", () => {
             assert.strictEqual(analysis.phaseStatus.deployGoals, false);
         });
 
+        it("should return empty fingerprints", async () => {
+            const pli: PushListenerInvocation = { push: {} } as any;
+            const p = InMemoryProject.of();
+            const analysis = await analyzerBuilder({} as any)
+                .withScanner(toyScanner)
+                .build()
+                .analyze(p, pli, { full: true });
+            assert.deepStrictEqual(analysis.fingerprints, {});
+        });
+
+        it("should consolidate one fingerprint", async () => {
+            const pli: PushListenerInvocation = { push: {} } as any;
+            const p = InMemoryProject.of();
+            const fp1 = {
+                name: "one",
+                version: "0.1.0",
+                abbreviation: "abc",
+                sha: "abcd",
+                data: "x",
+            };
+            const analysis = await analyzerBuilder({} as any)
+                .withScanner(async () => ({
+                    name: "foo",
+                    tags: [],
+                    fingerprints: [fp1],
+                }))
+                .build()
+                .analyze(p, pli, { full: true });
+            assert.deepStrictEqual(analysis.fingerprints, { one: fp1});
+        });
+
     });
 
     describe("interpretation", () => {

--- a/test/analysis/support/projectAnalysisUtils.test.ts
+++ b/test/analysis/support/projectAnalysisUtils.test.ts
@@ -78,5 +78,6 @@ function newAnalysis(): ProjectAnalysis {
         referencedEnvironmentVariables: [],
         services: {},
         messages: [],
+        fingerprints: {},
     };
 }


### PR DESCRIPTION
Scanning can now include fingerprints, which will be consolidated on `ProjectAnalysis`. This enables fingerprints to be queryable in analysis reporting.